### PR TITLE
Add loadvidapi as top-priority video downloader

### DIFF
--- a/new-bot/package.json
+++ b/new-bot/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "format": "eslint . --fix",
     "typecheck": "tsc",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
     "build": "tsc --noEmit false",
     "dev": "tsc-watch --onSuccess \"tsx -r dotenv/config -r newrelic ./src/main.ts\"",
     "start": "tsc && tsx -r dotenv/config -r newrelic ./src/main.ts",

--- a/new-bot/src/bot/features/download-video.ts
+++ b/new-bot/src/bot/features/download-video.ts
@@ -9,7 +9,9 @@ import axios from 'axios';
 import { addReplyParam } from "@roziscoding/grammy-autoquote";
 import { getVkVideoInfo, downloadVideo } from "../helpers/yt-dlp.js";
 import downloadFile from '../helpers/download-file.js';
+import { createLoadVidApiClient, LoadVidApiUnsupportedUrlError } from '../helpers/loadvidapi.js';
 import { config } from '#root/config.js';
+import { logger } from '#root/logger.js';
 import { randomUUID } from 'node:crypto';
 import { toError } from '../utils/error-prettier.js';
 
@@ -25,6 +27,16 @@ const PH_VIDEO_DURATION = 10;
 const COBALT_API_URL = config.COBALT_API_URL;
 const COBALT_PROXY_API_URL = config.COBALT_PROXIED_API_URL;
 const FASTSAVER_API_TOKEN = config.FSA_TOKEN;
+
+// loadvidapi is tried first for all supported services; the legacy chains
+// (Cobalt / FastSaver / yt-dlp) below stay as fallbacks. No token — no loadvidapi
+const loadVidApi = config.LOADVIDAPI_TOKEN
+  ? createLoadVidApiClient({
+      baseUrl: config.LOADVIDAPI_URL,
+      token: config.LOADVIDAPI_TOKEN,
+      logger,
+    })
+  : null;
 
 const composer = new Composer<Context>();
 const feature = composer;
@@ -46,7 +58,7 @@ const feature = composer;
 // https://x.com/Catshealdeprsn/status/1824921646181847112
 // https://twitter.com/Catshealdeprsn/status/1824921646181847112
 
-type SupportedVideoService = 'yt' | 'ig' | 'tw' | 'vk' | 'other';
+type SupportedVideoService = 'yt' | 'ig' | 'tw' | 'vk' | 'tt' | 'other';
 
 
 function isSupportedVideoUrl(url: string): { supported: boolean; service?: SupportedVideoService } {
@@ -61,7 +73,11 @@ function isSupportedVideoUrl(url: string): { supported: boolean; service?: Suppo
       "instagram.com": "ig",
       "twitter.com": "tw",
       "x.com": "tw",
-      "vk.com": "vk"
+      "vk.com": "vk",
+      // TikTok is only reachable through loadvidapi, there is no legacy chain for it
+      "tiktok.com": "tt",
+      "vm.tiktok.com": "tt",
+      "vt.tiktok.com": "tt"
     } as const;
 
     const service = supportedServices[hostname as keyof typeof supportedServices];
@@ -103,11 +119,33 @@ function generateVideoCaption(sourceUrl: string, service?: SupportedVideoService
   return caption;
 }
 
-async function processVideoUrl(url: string, ctx: Context, isVideoRequired: boolean = true): 
-Promise<{success: boolean, videoFileUrl?: string, videoFilePath?: string, service?: SupportedVideoService, customBackend?: 'proxy' | 'FSA' }> {
+// Tries the loadvidapi resolver. Returns a local file path on success,
+// undefined when loadvidapi is disabled or failed — the caller then
+// falls back to the legacy download chain
+async function tryLoadVidApi(url: string, ctx: Context): Promise<string | undefined> {
+  if (!loadVidApi) {
+    return undefined;
+  }
+  try {
+    const { filePath, job } = await loadVidApi.resolveAndDownload(url);
+    ctx.logger.debug(`loadvidapi resolved ${url} (job ${job.jobId}, service ${job.detectedService})`);
+    return filePath;
+  } catch (error) {
+    if (error instanceof LoadVidApiUnsupportedUrlError) {
+      ctx.logger.warn(`loadvidapi does not support URL ${url}, falling back`);
+    } else {
+      ctx.logger.warn(`loadvidapi failed for ${url}, falling back to legacy downloaders: ${error}`);
+    }
+    newrelic.incrementMetric("features/download-video/loadvidapi-fallback", 1);
+    return undefined;
+  }
+}
+
+async function processVideoUrl(url: string, ctx: Context, isVideoRequired: boolean = true):
+Promise<{success: boolean, videoFileUrl?: string, videoFilePath?: string, service?: SupportedVideoService, customBackend?: 'proxy' | 'FSA' | 'lvapi' }> {
   let parsedUrl;
   let service: SupportedVideoService = 'other';
-  let customBackend: 'proxy' | 'FSA' | undefined = undefined;
+  let customBackend: 'proxy' | 'FSA' | 'lvapi' | undefined = undefined;
   try {
     ctx.logger.debug(`Processing URL: ${url}`);
     
@@ -143,8 +181,16 @@ Promise<{success: boolean, videoFileUrl?: string, videoFilePath?: string, servic
     if (ctx.chat?.id) {
       ctx.replyWithChatAction("upload_video");
     }
-    // Try first without proxy, then with proxy if needed
     if (isVideoRequired){
+      // Top-priority attempt: internal loadvidapi resolver
+      videoFilePath = await tryLoadVidApi(url, ctx);
+      if (videoFilePath) {
+        service = 'ig';
+        customBackend = 'lvapi';
+      }
+    }
+    // Legacy chain: Cobalt direct → Cobalt proxy → FastSaverAPI
+    if (isVideoRequired && !videoFilePath){
       // First attempt without proxy
       const directResult = await fetchInstagramVideoUrl(url, false);
       if (directResult.success) {
@@ -200,27 +246,35 @@ Promise<{success: boolean, videoFileUrl?: string, videoFilePath?: string, servic
       ctx.replyWithChatAction("upload_video");
     }
     if (isVideoRequired){
-      // Try without proxy first
-      const cobaltToolsResult = await fetchYoutubeVideoUrl(url, false);
-      videoFileUrl = cobaltToolsResult.url;
-      
-      // If first attempt fails, try with proxy
-      if (!videoFileUrl) {
-        ctx.logger.debug(`Direct YouTube download failed, trying with proxy`);
-        const proxyResult = await fetchYoutubeVideoUrl(url, true);
-        videoFileUrl = proxyResult.url;
+      // Top-priority attempt: internal loadvidapi resolver
+      videoFilePath = await tryLoadVidApi(url, ctx);
+      if (videoFilePath) {
+        customBackend = 'lvapi';
       }
-  
-      if (!videoFileUrl) {
-        // We need to use a fallback local yt-dlp download
-        ctx.logger.debug(`Using yt-dlp to download video`);
-        try {
-          videoFilePath = await downloadVideo(url);
-        } catch (error) {
-          ctx.logger.error(`Error downloading video with yt-dlp:`);
-          newrelic.noticeError(toError(error), { url, ctx: JSON.stringify(ctx) });
-          console.log(error);
-          throw error;
+
+      if (!videoFilePath) {
+        // Legacy chain: try Cobalt without proxy first
+        const cobaltToolsResult = await fetchYoutubeVideoUrl(url, false);
+        videoFileUrl = cobaltToolsResult.url;
+
+        // If first attempt fails, try with proxy
+        if (!videoFileUrl) {
+          ctx.logger.debug(`Direct YouTube download failed, trying with proxy`);
+          const proxyResult = await fetchYoutubeVideoUrl(url, true);
+          videoFileUrl = proxyResult.url;
+        }
+
+        if (!videoFileUrl) {
+          // We need to use a fallback local yt-dlp download
+          ctx.logger.debug(`Using yt-dlp to download video`);
+          try {
+            videoFilePath = await downloadVideo(url);
+          } catch (error) {
+            ctx.logger.error(`Error downloading video with yt-dlp:`);
+            newrelic.noticeError(toError(error), { url, ctx: JSON.stringify(ctx) });
+            console.log(error);
+            throw error;
+          }
         }
       }
   
@@ -239,21 +293,45 @@ Promise<{success: boolean, videoFileUrl?: string, videoFilePath?: string, servic
 
   // Twitter parsing
   if (hostname == "twitter.com" || hostname == "x.com") {
-    // Try without proxy first, then with proxy if needed
-    let result = await fetchTwitterVideoUrl(url, false);
-    
-    // If direct attempt fails, try with proxy
-    if (!result.success) {
-      ctx.logger.debug(`Direct Twitter download failed, trying with proxy`);
-      result = await fetchTwitterVideoUrl(url, true);
-    }
-    
-    ctx.logger.debug(`Twitter result: ${JSON.stringify(result)}`);
-    videoFileUrl = result.url;
     if (ctx.chat?.id) {
       ctx.replyWithChatAction("upload_video");
     }
+    if (isVideoRequired) {
+      // Top-priority attempt: internal loadvidapi resolver
+      videoFilePath = await tryLoadVidApi(url, ctx);
+      if (videoFilePath) {
+        customBackend = 'lvapi';
+      }
+    }
+    if (!videoFilePath) {
+      // Legacy chain: try without proxy first, then with proxy if needed
+      let result = await fetchTwitterVideoUrl(url, false);
+
+      // If direct attempt fails, try with proxy
+      if (!result.success) {
+        ctx.logger.debug(`Direct Twitter download failed, trying with proxy`);
+        result = await fetchTwitterVideoUrl(url, true);
+      }
+
+      ctx.logger.debug(`Twitter result: ${JSON.stringify(result)}`);
+      videoFileUrl = result.url;
+    }
     service = 'tw';
+  }
+
+  // TikTok goes through loadvidapi only. Without a configured token the branch
+  // is skipped entirely and TikTok links are ignored, exactly as before
+  if (loadVidApi && (hostname === "tiktok.com" || hostname === "vm.tiktok.com" || hostname === "vt.tiktok.com")) {
+    if (ctx.chat?.id) {
+      ctx.replyWithChatAction("upload_video");
+    }
+    if (isVideoRequired) {
+      videoFilePath = await tryLoadVidApi(url, ctx);
+      if (videoFilePath) {
+        customBackend = 'lvapi';
+      }
+    }
+    service = 'tt';
   }
 
   if (hostname == "vk.com") {

--- a/new-bot/src/bot/features/download-video.ts
+++ b/new-bot/src/bot/features/download-video.ts
@@ -443,7 +443,15 @@ async function fetchTwitterVideoUrl(twitterUrl: string, useProxy: boolean = fals
 
     console.log(`Twitter response (${useProxy ? 'proxy' : 'direct'}): ${JSON.stringify(response.data)}`);
 
-    if (['success', 'redirect', 'tunnel'].includes(response.data.status) && response.data.url && !response.data.url.includes('.jpg') && !response.data.url.includes('.png')) {
+    // Cobalt tunnel urls carry no file extension, so the reported filename must be
+    // checked as well — tweets with photos must not be posted as videos
+    const responseUrl = typeof response.data.url === 'string' ? response.data.url.toLowerCase() : '';
+    const responseFilename = typeof response.data.filename === 'string' ? response.data.filename.toLowerCase() : '';
+    const isImage = ['.jpg', '.jpeg', '.png', '.webp', '.heic'].some(
+      (ext) => responseUrl.includes(ext) || responseFilename.includes(ext)
+    );
+
+    if (['success', 'redirect', 'tunnel'].includes(response.data.status) && response.data.url && !isImage) {
       return { success: true, url: response.data.url };
     } else {
       return { success: false, message: response.data };

--- a/new-bot/src/bot/helpers/loadvidapi.test.ts
+++ b/new-bot/src/bot/helpers/loadvidapi.test.ts
@@ -1,0 +1,310 @@
+import { describe, test, after } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  createLoadVidApiClient,
+  LoadVidApiAuthError,
+  LoadVidApiError,
+  LoadVidApiJobFailedError,
+  LoadVidApiTimeoutError,
+  LoadVidApiUnsupportedUrlError,
+} from "./loadvidapi.js";
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const testTmpDir = path.join(os.tmpdir(), `loadvidapi-test-${process.pid}`);
+
+after(async () => {
+  await fs.rm(testTmpDir, { recursive: true, force: true });
+});
+
+interface RecordedRequest {
+  method: string;
+  url: string;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}
+
+interface MockServer {
+  url: string;
+  requests: RecordedRequest[];
+  close: () => Promise<void>;
+}
+
+function startMockServer(
+  handler: (req: RecordedRequest, res: http.ServerResponse) => void,
+): Promise<MockServer> {
+  const requests: RecordedRequest[] = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      const recorded: RecordedRequest = {
+        method: req.method ?? "",
+        url: req.url ?? "",
+        headers: req.headers,
+        body,
+      };
+      requests.push(recorded);
+      handler(recorded, res);
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address() as AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        requests,
+        close: () => new Promise<void>((r) => server.close(() => r())),
+      });
+    });
+  });
+}
+
+function sendJson(res: http.ServerResponse, status: number, payload: unknown) {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function makeClient(baseUrl: string, overrides: Record<string, unknown> = {}) {
+  return createLoadVidApiClient({
+    baseUrl,
+    token: "test-token",
+    logger: silentLogger,
+    requestTimeoutMs: 1000,
+    pollIntervalMs: 10,
+    jobTimeoutMs: 1000,
+    tmpDirPath: testTmpDir,
+    ...overrides,
+  });
+}
+
+describe("createJob", () => {
+  test("creates a job and returns jobId", async () => {
+    const server = await startMockServer((req, res) => {
+      sendJson(res, 201, { jobId: "job-1", status: "PENDING" });
+    });
+    try {
+      const client = makeClient(server.url);
+      const job = await client.createJob("https://www.instagram.com/reel/abc/");
+
+      assert.equal(job.jobId, "job-1");
+      assert.equal(job.status, "PENDING");
+      assert.equal(server.requests.length, 1);
+      const request = server.requests[0];
+      assert.equal(request.method, "POST");
+      assert.equal(request.url, "/jobs");
+      assert.equal(request.headers.authorization, "Bearer test-token");
+      assert.match(request.headers["content-type"] ?? "", /application\/json/);
+      assert.deepEqual(JSON.parse(request.body), {
+        videoUrl: "https://www.instagram.com/reel/abc/",
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("throws LoadVidApiUnsupportedUrlError on 400 without retrying", async () => {
+    const server = await startMockServer((req, res) => {
+      sendJson(res, 400, { error: "Unsupported URL" });
+    });
+    try {
+      const client = makeClient(server.url);
+      await assert.rejects(
+        client.createJob("https://example.com/not-a-video"),
+        LoadVidApiUnsupportedUrlError,
+      );
+      assert.equal(server.requests.length, 1);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("throws LoadVidApiAuthError on 401", async () => {
+    const server = await startMockServer((req, res) => {
+      sendJson(res, 401, { error: "Unauthorized" });
+    });
+    try {
+      const client = makeClient(server.url);
+      await assert.rejects(
+        client.createJob("https://www.instagram.com/reel/abc/"),
+        LoadVidApiAuthError,
+      );
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe("waitForResult", () => {
+  test("polls until COMPLETED and returns the job with resultUrl", async () => {
+    const statuses = ["PENDING", "ACTIVE", "COMPLETED"];
+    let pollCount = 0;
+    const server = await startMockServer((req, res) => {
+      const status = statuses[Math.min(pollCount, statuses.length - 1)];
+      pollCount += 1;
+      sendJson(res, 200, {
+        jobId: "job-2",
+        status,
+        resultUrl: status === "COMPLETED" ? "https://cdn.example.com/v.mp4" : null,
+        detectedService: "instagram",
+      });
+    });
+    try {
+      const client = makeClient(server.url);
+      const job = await client.waitForResult("job-2");
+
+      assert.equal(job.status, "COMPLETED");
+      assert.equal(job.resultUrl, "https://cdn.example.com/v.mp4");
+      assert.equal(pollCount, 3);
+      for (const request of server.requests) {
+        assert.equal(request.method, "GET");
+        assert.equal(request.url, "/jobs/job-2");
+        assert.equal(request.headers.authorization, "Bearer test-token");
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("throws LoadVidApiJobFailedError with lastError on FAILED", async () => {
+    const server = await startMockServer((req, res) => {
+      sendJson(res, 200, {
+        jobId: "job-3",
+        status: "FAILED",
+        lastError: "All providers exhausted",
+      });
+    });
+    try {
+      const client = makeClient(server.url);
+      await assert.rejects(client.waitForResult("job-3"), (error: unknown) => {
+        assert.ok(error instanceof LoadVidApiJobFailedError);
+        assert.match(error.message, /All providers exhausted/);
+        return true;
+      });
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("times out after jobTimeoutMs and does not cancel the job", async () => {
+    const server = await startMockServer((req, res) => {
+      sendJson(res, 200, { jobId: "job-4", status: "PENDING" });
+    });
+    try {
+      const client = makeClient(server.url, { jobTimeoutMs: 100, pollIntervalMs: 20 });
+      await assert.rejects(client.waitForResult("job-4"), LoadVidApiTimeoutError);
+      // The API has no cancellation endpoint — only GET polling is expected
+      assert.ok(server.requests.length >= 1);
+      for (const request of server.requests) {
+        assert.equal(request.method, "GET");
+      }
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("throws LoadVidApiAuthError on 401 during polling", async () => {
+    const server = await startMockServer((req, res) => {
+      sendJson(res, 401, { error: "Unauthorized" });
+    });
+    try {
+      const client = makeClient(server.url);
+      await assert.rejects(client.waitForResult("job-5"), LoadVidApiAuthError);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe("download", () => {
+  test("streams the file to a local path without the API auth header", async () => {
+    const videoBytes = "FAKE_MP4_BYTES";
+    const server = await startMockServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "video/mp4" });
+      res.end(videoBytes);
+    });
+    try {
+      const client = makeClient(server.url);
+      const filePath = await client.download(`${server.url}/files/v.mp4`);
+
+      const content = await fs.readFile(filePath, "utf8");
+      assert.equal(content, videoBytes);
+      // resultUrl points to an external CDN, the API token must not leak there
+      assert.equal(server.requests[0].headers.authorization, undefined);
+      await fs.unlink(filePath);
+    } finally {
+      await server.close();
+    }
+  });
+
+  test("throws LoadVidApiError on non-2xx download response", async () => {
+    const server = await startMockServer((req, res) => {
+      sendJson(res, 404, { error: "Gone" });
+    });
+    try {
+      const client = makeClient(server.url);
+      await assert.rejects(client.download(`${server.url}/files/v.mp4`), LoadVidApiError);
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+describe("resolveAndDownload", () => {
+  test("happy path: create job, poll to COMPLETED, download the file", async () => {
+    const videoBytes = "REAL_VIDEO_CONTENT";
+    let pollCount = 0;
+    const server = await startMockServer((req, res) => {
+      if (req.method === "POST" && req.url === "/jobs") {
+        sendJson(res, 201, { jobId: "job-6", status: "PENDING" });
+        return;
+      }
+      if (req.method === "GET" && req.url === "/jobs/job-6") {
+        pollCount += 1;
+        if (pollCount < 2) {
+          sendJson(res, 200, { jobId: "job-6", status: "ACTIVE" });
+        } else {
+          sendJson(res, 200, {
+            jobId: "job-6",
+            status: "COMPLETED",
+            resultUrl: `http://${req.headers.host}/files/result.mp4`,
+            detectedService: "twitter",
+          });
+        }
+        return;
+      }
+      if (req.method === "GET" && req.url === "/files/result.mp4") {
+        res.writeHead(200, { "Content-Type": "video/mp4" });
+        res.end(videoBytes);
+        return;
+      }
+      sendJson(res, 404, { error: "Not found" });
+    });
+    try {
+      const client = makeClient(server.url);
+      const { job, filePath } = await client.resolveAndDownload(
+        "https://x.com/user/status/123",
+      );
+
+      assert.equal(job.jobId, "job-6");
+      assert.equal(job.detectedService, "twitter");
+      const content = await fs.readFile(filePath, "utf8");
+      assert.equal(content, videoBytes);
+      await fs.unlink(filePath);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/new-bot/src/bot/helpers/loadvidapi.ts
+++ b/new-bot/src/bot/helpers/loadvidapi.ts
@@ -1,0 +1,186 @@
+import path from "node:path";
+import os from "node:os";
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import { pipeline } from "node:stream/promises";
+import { setTimeout as sleep } from "node:timers/promises";
+import axios from "axios";
+import { v4 as uuidv4 } from "uuid";
+
+export type LoadVidApiJobStatus = "PENDING" | "ACTIVE" | "COMPLETED" | "FAILED";
+
+export interface LoadVidApiJob {
+  jobId: string;
+  status: LoadVidApiJobStatus;
+  resultUrl?: string | null;
+  lastError?: string | null;
+  detectedService?: string | null;
+}
+
+type LogInput = string | Record<string, unknown>;
+
+export interface LoadVidApiLogger {
+  debug: (msg: LogInput) => void;
+  info: (msg: LogInput) => void;
+  warn: (msg: LogInput) => void;
+  error: (msg: LogInput) => void;
+}
+
+export class LoadVidApiError extends Error {}
+
+// 400 on job creation: the service does not support this URL, retrying is pointless
+export class LoadVidApiUnsupportedUrlError extends LoadVidApiError {}
+
+// 401: the configured LOADVIDAPI_TOKEN is invalid
+export class LoadVidApiAuthError extends LoadVidApiError {}
+
+export class LoadVidApiJobFailedError extends LoadVidApiError {
+  public readonly job: LoadVidApiJob;
+
+  constructor(job: LoadVidApiJob) {
+    super(`loadvidapi job ${job.jobId} failed: ${job.lastError ?? "unknown reason"}`);
+    this.job = job;
+  }
+}
+
+// The job did not reach a final status in time. The API has no cancellation,
+// so the server-side job is simply abandoned — that is expected
+export class LoadVidApiTimeoutError extends LoadVidApiError {
+  public readonly jobId: string;
+
+  constructor(jobId: string, timeoutMs: number) {
+    super(`loadvidapi job ${jobId} did not finish within ${timeoutMs}ms`);
+    this.jobId = jobId;
+  }
+}
+
+export interface LoadVidApiClientOptions {
+  baseUrl: string;
+  token: string;
+  logger?: LoadVidApiLogger;
+  requestTimeoutMs?: number;
+  pollIntervalMs?: number;
+  jobTimeoutMs?: number;
+  downloadTimeoutMs?: number;
+  tmpDirPath?: string;
+}
+
+export function createLoadVidApiClient(options: LoadVidApiClientOptions) {
+  const {
+    baseUrl,
+    token,
+    logger = console,
+    requestTimeoutMs = 10_000,
+    pollIntervalMs = 2_500,
+    jobTimeoutMs = 120_000,
+    downloadTimeoutMs = 120_000,
+    tmpDirPath = path.join(os.tmpdir(), "loadvidapi-temp"),
+  } = options;
+
+  const api = axios.create({
+    baseURL: baseUrl,
+    timeout: requestTimeoutMs,
+    headers: { Authorization: `Bearer ${token}` },
+    validateStatus: null,
+  });
+
+  function throwIfUnauthorized(status: number, context: string): void {
+    if (status === 401) {
+      logger.error({ msg: `loadvidapi rejected the configured token (401) during ${context}, check LOADVIDAPI_TOKEN` });
+      throw new LoadVidApiAuthError(`loadvidapi returned 401 during ${context}`);
+    }
+  }
+
+  async function createJob(videoUrl: string): Promise<LoadVidApiJob> {
+    const response = await api.post("/jobs", { videoUrl });
+    throwIfUnauthorized(response.status, "job creation");
+    if (response.status === 400) {
+      throw new LoadVidApiUnsupportedUrlError(`loadvidapi does not support this URL: ${videoUrl}`);
+    }
+    if (response.status !== 201) {
+      throw new LoadVidApiError(`loadvidapi job creation failed with HTTP ${response.status}`);
+    }
+    const job = response.data as LoadVidApiJob;
+    logger.info({ msg: "loadvidapi job created", jobId: job.jobId, videoUrl });
+    return job;
+  }
+
+  async function waitForResult(jobId: string): Promise<LoadVidApiJob> {
+    const deadline = Date.now() + jobTimeoutMs;
+    for (;;) {
+      let job: LoadVidApiJob | undefined;
+      try {
+        const response = await api.get(`/jobs/${jobId}`);
+        throwIfUnauthorized(response.status, "status polling");
+        if (response.status === 200) {
+          job = response.data as LoadVidApiJob;
+        } else {
+          logger.warn({ msg: "loadvidapi polling returned unexpected HTTP status", jobId, status: response.status });
+        }
+      } catch (error) {
+        if (error instanceof LoadVidApiError) {
+          throw error;
+        }
+        // Transient network errors should not kill the job before the deadline
+        logger.warn({ msg: "loadvidapi polling request failed", jobId, error: String(error) });
+      }
+
+      if (job?.status === "COMPLETED") {
+        logger.info({ msg: "loadvidapi job completed", jobId, detectedService: job.detectedService });
+        return job;
+      }
+      if (job?.status === "FAILED") {
+        logger.info({ msg: "loadvidapi job failed", jobId, lastError: job.lastError });
+        throw new LoadVidApiJobFailedError(job);
+      }
+
+      if (Date.now() + pollIntervalMs > deadline) {
+        logger.info({ msg: "loadvidapi job timed out on the client side", jobId });
+        throw new LoadVidApiTimeoutError(jobId, jobTimeoutMs);
+      }
+      await sleep(pollIntervalMs);
+    }
+  }
+
+  // resultUrl is an external direct link, so no Authorization header here
+  async function download(resultUrl: string): Promise<string> {
+    await fsPromises.mkdir(tmpDirPath, { recursive: true });
+    const filePath = path.join(tmpDirPath, `${Date.now()}-${uuidv4()}.mp4`);
+
+    const response = await axios.get(resultUrl, {
+      responseType: "stream",
+      timeout: requestTimeoutMs,
+      validateStatus: null,
+    });
+    if (response.status < 200 || response.status >= 300) {
+      response.data.destroy();
+      throw new LoadVidApiError(`loadvidapi result file download failed with HTTP ${response.status}`);
+    }
+
+    try {
+      await pipeline(response.data, fs.createWriteStream(filePath), {
+        signal: AbortSignal.timeout(downloadTimeoutMs),
+      });
+    } catch (error) {
+      await fsPromises.unlink(filePath).catch(() => {});
+      throw error;
+    }
+    return filePath;
+  }
+
+  // Result links can be short-lived, so the file is downloaded
+  // immediately after the job completes — never store resultUrl for later
+  async function resolveAndDownload(videoUrl: string): Promise<{ job: LoadVidApiJob; filePath: string }> {
+    const created = await createJob(videoUrl);
+    const job = await waitForResult(created.jobId);
+    if (!job.resultUrl) {
+      throw new LoadVidApiError(`loadvidapi job ${job.jobId} completed without resultUrl`);
+    }
+    const filePath = await download(job.resultUrl);
+    return { job, filePath };
+  }
+
+  return { createJob, waitForResult, download, resolveAndDownload };
+}
+
+export type LoadVidApiClient = ReturnType<typeof createLoadVidApiClient>;

--- a/new-bot/src/config.ts
+++ b/new-bot/src/config.ts
@@ -38,7 +38,11 @@ const createConfigFromEnvironment = (environment: NodeJS.ProcessEnv) => {
     COBALT_API_URL: z.string(),
     // URL for proxied Cobalt API, used as fallback when direct API calls fail
     COBALT_PROXIED_API_URL: z.string(),
-    FSA_TOKEN: z.string().optional()
+    FSA_TOKEN: z.string().optional(),
+    // loadvidapi — internal async video resolver, tried first for supported services.
+    // Empty token disables the integration entirely (legacy chains keep working)
+    LOADVIDAPI_URL: z.string().default("https://loadvidapi.fox.wf"),
+    LOADVIDAPI_TOKEN: z.string().default("")
   });
 
   if (config.BOT_MODE === "webhook") {


### PR DESCRIPTION
Internal loadvidapi resolver is tried first for Instagram, YouTube, Twitter/X and TikTok (new); legacy Cobalt/FastSaver/yt-dlp chains remain as fallbacks. Integration is disabled unless LOADVIDAPI_TOKEN is set, so behavior is unchanged without the token.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded video download support for more social platforms, including TikTok.
  * Added a new fallback download path that can improve success rates when the primary route fails.
* **Bug Fixes**
  * Improved detection of image-based responses so video downloads are less likely to be misclassified.
  * Enhanced error handling and retry behavior during video resolution and download.
* **Chores**
  * Added environment settings for the new download integration and a test command for automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->